### PR TITLE
Grippie cursor icon changed to row-resize

### DIFF
--- a/src/css/navbar.less
+++ b/src/css/navbar.less
@@ -51,6 +51,7 @@
         background-position: center center;
         background-repeat:   repeat-x;
         border: none;
+        cursor: row-resize;
         .opacity(50);
         &:hover {
             .opacity(100);


### PR DESCRIPTION
Something that bothered me for some time. It's easier to notice that you can actually pull it.
