### PR TITLE
Change the http version from 1.0 to 1.1 in PHP

### DIFF
--- a/src/php/Genghis/Response.php
+++ b/src/php/Genghis/Response.php
@@ -50,7 +50,8 @@ class Genghis_Response
 
     protected function renderHeaders()
     {
-        header(sprintf('HTTP/1.0 %s %s', $this->status, self::$statusCodes[$this->status]));
+        $version = ($_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.0') ? '1.0' : '1.1';
+        header(sprintf('HTTP/%s %s %s', $version, $this->status, self::$statusCodes[$this->status]));
         foreach ($this->headers as $name => $val) {
             header(sprintf('%s: %s', $name, $val));
         }


### PR DESCRIPTION
Why is the requests served with a `HTTP/1.0` header?

Without this patch, on one of my setup, upgrading from Apache 2.2 to Apache 2.4 would make the request for the JS asset hang.
To be more specific: if the JS asset was under 8000 bytes (exactly), the request would go through perfectly and Apache would add the appropriate `Content-Length` header. Over 8000 bytes, Apache would serve only part of what was printed by the php script and then hang until the client timed out. (Using the PHP function `error_log` I was able to make sure the PHP script actually returned, and printed everything).
With this patch, for a JS asset over 8000 bytes, Apache switches to a `Transfer-Encoding: chunked` header (instead of the `Content-Length` one) and serve the response perfectly.

I have no idea what is the underlying problem, but updating to HTTP/1.1 makes Apache happy.
Another option would be to use `$_SERVER["SERVER_PROTOCOL"]` instead of `HTTP/1.1`

Or, even better, if Genghis is not supposed to run on PHP < 5.4, this whole line should be replaced by `http_response_code($this->status);` and the `statusCodes` array could be dropped.
